### PR TITLE
Merged stop words "crypto" and "encryption" to just "crypt"

### DIFF
--- a/low-checker.user.js
+++ b/low-checker.user.js
@@ -37,9 +37,8 @@
 
     const config = configHelper.getConfig(CONFIG_NAMESPACE);
     const stopWordsDictionary = [
-        "crypto", "крипто",
+        "crypt", "крипто", "шифрован",
         "daemon", "демон",
-        "encryption", "шифрован",
         "page", "страниц"
     ];
     stopWordsDictionary.push(...config.blackListValidatorDictionary);


### PR DESCRIPTION
This will allow to catch words as "encrypting", "encrypted" etc.

Протестировано на списке:

- Development of the functionality for en**crypt**ing user messages.
- Разработка функциональности для **шифрован**ия сообщений пользователя.
- Разработка функциональности для обмена **крипто**валют.