### PR TITLE
Validator for incorrect quotes (and other non-ASCII symbols)

### DIFF
--- a/low-checker.user.js
+++ b/low-checker.user.js
@@ -43,6 +43,8 @@
         "page", "страниц"
     ];
     stopWordsDictionary.push(...config.blackListValidatorDictionary);
+    // regexp allows all standard ASCII characters and Unicode Cyrillic characters
+    const nonAsciiRegexp = /[^\x00-\x7F\u0400-\u04FF]/g;
     const matcher = config.targetElementMatchers.find(el =>
         new RegExp(el.urlPattern).test(window.location.href)
     );
@@ -73,6 +75,15 @@
         oneSentencePerLineValidator: function (line) {
             const parts = line.split('.');
             return parts.length > 2 ? "Suspected: more than one sentence in one line." : "";
+        },
+        nonAsciiValidator: function (line) {
+            const nonAsciiSymbols = line.match(nonAsciiRegexp);
+            const numSymbols = nonAsciiSymbols?.length;
+            if (numSymbols) {
+                const symbolsToShow = numSymbols > 5 ? [...nonAsciiSymbols.slice(0, 5), 'etc.'] : nonAsciiSymbols;
+                return `${numSymbols} incorrect symbols were detected: ${symbolsToShow.join(" ")}`;
+            }
+            return "";
         }
     };
 

--- a/low-checker.user.js
+++ b/low-checker.user.js
@@ -79,11 +79,9 @@
         nonAsciiValidator: function (line) {
             const nonAsciiSymbols = line.match(nonAsciiRegexp);
             const numSymbols = nonAsciiSymbols?.length;
-            if (numSymbols) {
-                const symbolsToShow = numSymbols > 5 ? [...nonAsciiSymbols.slice(0, 5), 'etc.'] : nonAsciiSymbols;
-                return `${numSymbols} incorrect symbols were detected: ${symbolsToShow.join(" ")}`;
-            }
-            return "";
+            return numSymbols
+                ? `${numSymbols} incorrect symbols were detected: ${nonAsciiSymbols.slice(0, 5).join(", ")}${numSymbols > 5 ? ", etc." : "." }`
+                : "";
         }
     };
 


### PR DESCRIPTION
Добавил валидатор, чтоб отлавливать вордовские кавычки типа `«word»` или `“word”`

![image](https://github.com/user-attachments/assets/5a1e44a3-2d2a-49b7-a3a1-4ae6462c1ab1)
